### PR TITLE
5 twitter content too long

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 discord.py==2.3.2
 requests==2.31.0
-openai==1.3.5
+openai==1.50.2
 airtable-python-wrapper==0.15.3
 pillow==10.1.0
 python-dotenv==1.0.0

--- a/src/handlers/content_generator.py
+++ b/src/handlers/content_generator.py
@@ -8,11 +8,43 @@ from ..utils.config import (
     GEN_PARAMS,
 )
 
+from typing import Optional
+
 # Initialize the OpenAI client
 client = OpenAI(api_key=OPENAI_API_KEY)
 
 
+def load_or_create_assistant(assistant_name: str, platform: str):
+    """
+    Load or create an assistant given the assistant name.  Use the instructions for the relevant platform.
+    """
+    # TODO: this function should formulate the assistant name and load or create
+    return
+
+
+def get_new_thread_id():
+    """
+    Create a new thread and return the thread id.
+    """
+    return
+
+
+def get_n_chr(text: str):
+    """
+    Count and return the number of characters in a string.
+    """
+    return
+
+
+def shorten_content():
+    """
+    Shorten the content on the given thread and return the new content.
+    """
+    return
+
+
 def generate_content(article_text, platform):
+    # TODO: alter to work with assistants
     """
     Generate social media content based on the article text and platform.
     """
@@ -52,6 +84,13 @@ def lambda_handler(event, context):
         return {"statusCode": 200, "body": json.dumps({"generated_content": result})}
     except Exception as e:
         return {"statusCode": 400, "body": json.dumps({"error": str(e)})}
+
+
+def regenerate_content(thread_id: str, user_message: Optional[str] = None):
+    """
+    Regenerate content associated with a given thread.  Optionally, add a user message to the prompt.
+    """
+    return
 
 
 # For local testing

--- a/src/handlers/content_generator.py
+++ b/src/handlers/content_generator.py
@@ -43,21 +43,7 @@ def _load_or_create_assistant(platform: str):
         return f"Error getting or creating assistant: {str(e)}"
 
 
-def get_n_chr(text: str):
-    """
-    Count and return the number of characters in a string.
-    """
-    return
-
-
-def shorten_content():
-    """
-    Shorten the content on the given thread and return the new content.
-    """
-    return
-
-
-def generate_content(article_text, platform):
+def generate_content(article_text: str, platform: str):
     """
     Generate social media content based on the article text and platform.
     """
@@ -91,6 +77,37 @@ def generate_content(article_text, platform):
 
     except Exception as e:
         return f"Error generating content: {str(e)}"
+
+
+def shorten_content(thread_id: str, platform: str):
+    """
+    Shorten the content on the given thread and return the new content.
+    """
+    try:
+        # check platform
+        if platform not in CONTENT_ASSISTANT_CONFIGS:
+            raise ValueError(f"Unsupported platform: {platform}")
+
+        # get assistant
+        assistant_id = _load_or_create_assistant(platform)
+
+        # request shortened content
+        message = client.beta.threads.messages.create(
+            thread_id,
+            content=f"Please shorten the content generated in the previous message, while keeping as much of the original content and intent as possible.",
+            role="user",
+        )
+        run_result = client.beta.threads.runs.create_and_poll(
+            thread_id=thread_id, assistant_id=assistant_id, poll_interval_ms=2000
+        )
+        content_response = client.beta.threads.messages.list(
+            thread_id, limit=1, order="desc"
+        )
+
+        return content_response.data[0].content[0].text.value
+
+    except Exception as e:
+        return f"Error shortening content: {str(e)}"
 
 
 def lambda_handler(event, context):

--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,8 @@ from .handlers import (
 )
 from .utils.config import DISCORD_TOKEN, CHANNEL_ID
 
+from typing import Optional
+
 intents = discord.Intents.default()
 intents.message_content = True
 bot = commands.Bot(command_prefix="!", intents=intents)
@@ -121,6 +123,15 @@ async def post_twitter(ctx, content_id: str):
         # Update Airtable to mark content as posted
         update_result = airtable_manager.update_content_status(content_id, "Y")
         await ctx.send(f"Airtable record {content_id} updated as posted.")
+
+
+@bot.command(name="regenerate_content")
+async def regenerate_content(ctx, content_id: str, user_message: Optional[str] = None):
+    """
+    Regenerate content for given content_id.  Optionally include user message in prompt.
+    Usage: !regenerate_content
+    """
+    return
 
 
 if __name__ == "__main__":

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -56,21 +56,23 @@ def get_instructions(filename):
         return file.read()
 
 
-# Load system prompts
+# Load instructions
 PROCESSOR_INSTRUCTIONS = get_instructions("processor_instructions.txt")
-# if a platform's instructions are updated, the corresponding version number must be increased
-# otherwise the updated instructions will not be used
-CONTENT_INSTRUCTIONS_X = get_instructions("content_instructions_x.txt")
-VERSION_X = 1
 IMAGE_INSTRUCTIONS = get_instructions("image_instructions.txt")
 
-# Social media generation params
-GEN_PARAMS = {
+# load content assistant configs
+# if a platform's instructions are updated, the corresponding version number must be increased
+# otherwise the updated instructions will not be used
+CONTENT_ASSISTANT_CONFIGS = {
     "X": {
-        "temperature": 1,
-        "max_tokens": 85,
-        "top_p": 1,
-        "frequency_penalty": 0,
-        "presence_penalty": 0,
+        "version": 1,
+        "instructions": get_instructions("content_instructions_x.txt"),
+        "gen_params": {
+            "temperature": 1,
+            "max_tokens": 85,
+            "top_p": 1,
+            "frequency_penalty": 0,
+            "presence_penalty": 0,
+        },
     }
 }

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -58,7 +58,10 @@ def get_instructions(filename):
 
 # Load system prompts
 PROCESSOR_INSTRUCTIONS = get_instructions("processor_instructions.txt")
+# if a platform's instructions are updated, the corresponding version number must be increased
+# otherwise the updated instructions will not be used
 CONTENT_INSTRUCTIONS_X = get_instructions("content_instructions_x.txt")
+VERSION_X = 1
 IMAGE_INSTRUCTIONS = get_instructions("image_instructions.txt")
 
 # Social media generation params

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -61,8 +61,9 @@ PROCESSOR_INSTRUCTIONS = get_instructions("processor_instructions.txt")
 IMAGE_INSTRUCTIONS = get_instructions("image_instructions.txt")
 
 # load content assistant configs
-# if a platform's instructions are updated, the corresponding version number must be increased
-# otherwise the updated instructions will not be used
+# if a platform's instructions, gen params, or model are updated,
+# the corresponding version number must be increased
+# otherwise the previous assistant will be loaded
 CONTENT_ASSISTANT_CONFIGS = {
     "X": {
         "version": 1,

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -67,12 +67,7 @@ CONTENT_ASSISTANT_CONFIGS = {
     "X": {
         "version": 1,
         "instructions": get_instructions("content_instructions_x.txt"),
-        "gen_params": {
-            "temperature": 1,
-            "max_tokens": 85,
-            "top_p": 1,
-            "frequency_penalty": 0,
-            "presence_penalty": 0,
-        },
-    }
+        "temperature": 1,
+        "top_p": 1,
+    },
 }


### PR DESCRIPTION
This PR adds the ability to check if a piece of social media content is too long and if so, asks the assistant to shorten it.  It also uses this functionality in `main.py` to check if tweets are above the limit of 280-23 characters, so they can be posted to the free version of twitter with the accompanying url.